### PR TITLE
OpenSpending redirects

### DIFF
--- a/ansible/roles/nginx/files/etc/nginx/s095.okserver.org/sites-available/openspending.org
+++ b/ansible/roles/nginx/files/etc/nginx/s095.okserver.org/sites-available/openspending.org
@@ -63,9 +63,9 @@ server {
   rewrite ^/dataset/italyregionalaccounts /it-regional-accounts/embed?widget=treemap&state=%7B"drilldown"%3A"function"%2C"cuts"%3A%7B"year"%3A"2008"%7D%7D permanent;
 
   # blog
-  rewrite ^/blog/index.html$ http://community.openspending.org/blog permanent;
+  rewrite ^/blog/index.html$ http://community.openspending.org/blog/ permanent;
   rewrite ^/blog/feed.rss$   http://community.openspending.org/feed/ permanent;
-  rewrite ^/blog/?$          http://community.openspending.org/blog permanent;
+  rewrite ^/blog/?$          http://community.openspending.org/blog/ permanent;
   rewrite ^/blog/(\d{4})/(\d{2})/\d{2}/(.*).html$  http://community.openspending.org/blog/$1/$2/$3 permanent;
 
   # resources


### PR DESCRIPTION
Blog has been moved on community and redirects should remove the day and use only year and month.

Also fixed redirects for resources and added redirects for help and about which were missing.
