### PR TITLE
nginx: add cors header to redirects to openspending.org on port 443

### DIFF
--- a/ansible/roles/nginx/files/etc/nginx/s095.okserver.org/sites-available/openspending.org
+++ b/ansible/roles/nginx/files/etc/nginx/s095.okserver.org/sites-available/openspending.org
@@ -22,6 +22,9 @@ server {
 server {
   listen [::]:80;
   server_name openspending.org www.openspending.org;
+
+  add_header Access-Control-Allow-Origin *;
+
   return 301 https://openspending.org$request_uri;
 }
 
@@ -33,6 +36,8 @@ server {
   include ssl_params;
   ssl_certificate /etc/nginx/ssl/star_openspending_org.crt;
   ssl_certificate_key /etc/nginx/ssl/star_openspending_org.key;
+
+  add_header Access-Control-Allow-Origin *;
 
   return 301 https://openspending.org$request_uri;
 }


### PR DESCRIPTION
Various sites, like for example data.gov.uk don't work because CORS header is missing in the redirects. Here's the fix.
