### PR TITLE
Update apt-security-check

### DIFF
--- a/ansible/roles/scripts/files/opt/scripts/check_mk/apt-security-check
+++ b/ansible/roles/scripts/files/opt/scripts/check_mk/apt-security-check
@@ -80,7 +80,7 @@ def install_security_updates(pkgs):
 	#print myenv
 	for pkg in pkgs:
 	#	print 'installing security update -> ' + pkg
-		c = subprocess.Popen(["apt-get","install", "-y", pkg], env=myenv, stdout=subprocess.PIPE)
+		c = subprocess.Popen(["apt-get","install", "-y", "-o Dpkg::Options::=\"--force-confdef\"","-o Dpkg::Options::=\"--force-confold\"", pkg], env=myenv, stdout=subprocess.PIPE)
 		streamdata = c.communicate()[0]
 		if c.returncode != 0:
 	#		print 'exit: ' + str(c.returncode) + ' ,'  + 'install failed for ' + pkg


### PR DESCRIPTION
Added the --force-confdef (to make apt-get use the defailts) and --force-confold, to make apt-get use the conf file that we've changed when that's there.  You need to use both together.  See here - http://raphaelhertzog.com/2010/09/21/debian-conffile-configuration-file-managed-by-dpkg/
