### PR TITLE
Removed dependancy from postfix role on scripts

### DIFF
--- a/ansible/roles/postfix/meta/main.yml
+++ b/ansible/roles/postfix/meta/main.yml
@@ -1,3 +1,3 @@
----
-dependencies:
- - { role: scripts }
+#---
+#dependencies:
+# - { role: scripts }


### PR DESCRIPTION
Simply removes the dependency which means the bootstrap completes ok.
