### PR TITLE
S3cronfixes - fixed backup script for s134

### DIFF
--- a/ansible/roles/cron/files/etc/cron.daily/s134.okserver.org/backups_to_s3
+++ b/ansible/roles/cron/files/etc/cron.daily/s134.okserver.org/backups_to_s3
@@ -2,7 +2,7 @@
 
 set -eu
 
-/usr/bin/s3cmd sync /home/backup/mysql_backups s3://attic.okfn.org/ --config=/home/okfn/.s3 2>&1 > /home/backup/$(date +%s)_mysql_backup.log
-/usr/bin/s3cmd sync /home/backup/psql_backups s3://attic.okfn.org/ --config=/home/okfn/.s3 2>&1 > /home/backup/$(date +%s)_psql_backup.log
+/usr/local/bin/aws s3 sync /home/backup/mysql_backups/ s3://attic.okfn.org/mysql_backups/ --profile default 2>&1 > /home/backup/$(date +%s)_mysql_backup.log
+/usr/local/bin/aws s3 sync /home/backup/psql_backups/ s3://attic.okfn.org/psql_backups/ --profile default 2>&1 > /home/backup/$(date +%s)_psql_backup.log
 find /home/backup/mysql_backups -mtime +14 -exec rm {} \;
 find /home/backup/psql_backups -mtime +14 -exec rm {} \;


### PR DESCRIPTION
Changed backup script for s134, so it now uses aws cli.
