### PR TITLE
Add iptables rule for s124

### DIFF
--- a/ansible/inventory/host_vars/s124.okserver.org.yml
+++ b/ansible/inventory/host_vars/s124.okserver.org.yml
@@ -1,4 +1,6 @@
 ---
 backup_postgres: true
 backup_scripts:
-   - psql_backup.sh 
+   - psql_backup.sh
+custom_iptables_rules:
+   - "-A INPUT -j DROP -p tcp --destination-port 8080 --destination 88.80.190.91/32"


### PR DESCRIPTION
This blocks traffic to port 8080 to the external IP, while allowing traffic via
the internal IP. It's easier to do this for tomcat than mess with it's
configuration to listen on localhost and the private IP.