### PR TITLE
Explicitly disable passwords on sshd

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -33,6 +33,6 @@ sudo_default:
   - "%sysadmin"
 sudo_extras: []
 sudo_extra_lines: []
-
 postgres_port: 5432
 solr_port: 8983
+sshd_PasswordAuthentication: No


### PR DESCRIPTION
The Ubuntu default is to disable password authentication, so we should be good
pretty much everywhere anyway.