### PR TITLE
Remove existing database from destination app

### DIFF
--- a/ansible/roles/okfn-org-manager/files/copyapp
+++ b/ansible/roles/okfn-org-manager/files/copyapp
@@ -89,6 +89,9 @@ maybe quietly heroku pgbackups:capture -e -a "$DST_APP"
 status "enabling maintenance mode on destination app"
 maybe quietly heroku maintenance:on -a "$DST_APP"
 
+status "removing existing destination database"
+maybe quietly heroku pg:reset DATABASE_URL -a "$DST_APP" --confirm
+
 status "transferring data from source to destination"
 maybe quietly heroku pgbackups:transfer -a "$DST_APP" --confirm "$DST_APP" \
   "$SRC_APP"::DATABASE_URL DATABASE_URL


### PR DESCRIPTION
Heroku added a sanity check so you cannnot transfer to an app with an
existing database.