### PR TITLE
Give root sudo permissions

### DIFF
--- a/ansible/roles/sudo/templates/sudoers.j2
+++ b/ansible/roles/sudo/templates/sudoers.j2
@@ -1,4 +1,5 @@
 # {{ansible_managed}}
+root ALL=(ALL:ALL) ALL
 {% for i in sudo_users %}
 {{i}} ALL=(ALL) {{"NOPASSWD: " if sudo_nopasswd else ""}}ALL
 {% endfor %}


### PR DESCRIPTION
This removes a lot of unnecessary alerts and is a default entry in the
sudoers line on Ubuntu